### PR TITLE
fix #9 stacktrace works if triggered by a signal, eg SIGSEGV

### DIFF
--- a/libbacktrace_wrapper.c
+++ b/libbacktrace_wrapper.c
@@ -162,10 +162,8 @@ static int success_callback(void *data, uintptr_t pc __attribute__((unused)),
 		if (cb_data->next_index == 0)
 			fprintf(stderr, "libbacktrace error: no debugging symbols available. Compile with '--debugger:native'.\n");
 
-		if (debug)
-			return 0; // Keep going.
-		else
-			return 1; // Stop bulding the backtrace.
+    // see https://github.com/status-im/nim-libbacktrace/issues/9, we need to keep going here.
+		return 0;
 	}
 
 	char *demangled_function = demangle(function);

--- a/libbacktrace_wrapper.c
+++ b/libbacktrace_wrapper.c
@@ -162,7 +162,7 @@ static int success_callback(void *data, uintptr_t pc __attribute__((unused)),
 		if (cb_data->next_index == 0)
 			fprintf(stderr, "libbacktrace error: no debugging symbols available. Compile with '--debugger:native'.\n");
 
-    // see https://github.com/status-im/nim-libbacktrace/issues/9, we need to keep going here.
+		// see https://github.com/status-im/nim-libbacktrace/issues/9, we need to keep going here.
 		return 0;
 	}
 


### PR DESCRIPTION
fix #9
(that issue contains many other things, but these can be reported and addressed separately)

simple fix but it makes stacktraces work if triggered by a signal eg the common case of SIGSEGV.

/cc @stefantalpalaru

## future work
* make it easier to build nim with nim-libbacktrace + `--passc:"-fno-omit-frame-pointer -fno-optimize-sibling-calls"` to get the "best of both worlds": performance and good stacktraces