### PR TITLE
fix build output color on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 SHELL := bash # the shell used internally by Make
 
 NIM_PARAMS := -f --outdir:build --skipParentCfg:on --skipUserCfg:on $(NIMFLAGS)
-BUILD_MSG := "\\e[92mBuilding:\\e[39m"
+BUILD_MSG := "\\x1B[92mBuilding:\\x1B[39m"
 CMAKE := cmake
 CMAKE_MISSING_MSG := "CMake not installed. Aborting."
 


### PR DESCRIPTION
On macOS, `echo` does not support the `\e` extension from GNU coreutils.
Replacing with the portable `\x1B` to fix Terminal build output colors.