### PR TITLE
Pass length explicitly instead of relying on NULL terminators

### DIFF
--- a/libbacktrace.nim
+++ b/libbacktrace.nim
@@ -89,8 +89,8 @@ when not (defined(nimscript) or defined(js)):
 
     var
       length {.noinit.}: cint
-      functionInfoPtr = get_debugging_info_c(
-        addr programCounters[0], programCounters.len.cint,
+      functionInfoPtr = get_debugging_info_c(  # Nim 1.6 needs `unsafeAddr`
+        unsafeAddr programCounters[0], programCounters.len.cint,
         maxLength, addr length)
       iPtr = functionInfoPtr
       res: StackTraceEntry

--- a/libbacktrace/wrapper.nim
+++ b/libbacktrace/wrapper.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 Status Research & Development GmbH
+# Copyright (c) 2019-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0,
 #  * MIT license
@@ -28,16 +28,27 @@ proc get_backtrace_c*(): cstring {.
 
 # The returned array needs to be freed by the caller.
 # It holds at least a zero sentinel value at the end.
-proc get_program_counters_c*(max_length, skip: cint): ptr cuintptr_t {.
+proc get_program_counters_c*(
+    max_program_counters: cint,
+    num_program_counters: ptr cint,
+    skip: cint
+): ptr cuintptr_t {.
     importc: "get_program_counters_c", header: "libbacktrace_wrapper.h".}
 
-type
-  DebuggingInfo* {.importc: "struct debugging_info", header: "libbacktrace_wrapper.h", bycopy.} = object
-    filename* {.importc: "filename".}: cstring
-    lineno* {.importc: "lineno".}: cint
-    function* {.importc: "function".}: cstring
+type DebuggingInfo* {.
+    importc: "struct debugging_info",
+    header: "libbacktrace_wrapper.h",
+    bycopy.} = object
+  filename* {.importc: "filename".}: cstring
+  lineno* {.importc: "lineno".}: cint
+  function* {.importc: "function".}: cstring
 
 # The returned array needs to be freed by the caller.
 # Char pointers in the returned struct need to be freed by the caller.
-proc get_debugging_info_c*(program_counters: ptr cuintptr_t, max_length: cint): ptr DebuggingInfo {.
+proc get_debugging_info_c*(
+    program_counters: ptr cuintptr_t,
+    num_program_counters: cint,
+    max_debugging_infos: cint,
+    num_debugging_infos: ptr cint
+): ptr DebuggingInfo {.
     importc: "get_debugging_info_c", header: "libbacktrace_wrapper.h".}

--- a/libbacktrace_wrapper.h
+++ b/libbacktrace_wrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Status Research & Development GmbH
+ * Copyright (c) 2019-2024 Status Research & Development GmbH
  * Licensed under either of
  *  * Apache License, version 2.0,
  *  * MIT license
@@ -25,9 +25,9 @@ char *get_backtrace_c(void) __attribute__((noinline));
 
 /*
  * The returned array needs to be freed by the caller.
- * It holds at least a zero sentinel value at the end.
  */
-uintptr_t *get_program_counters_c(int max_length, int skip) __attribute__((noinline));
+uintptr_t *get_program_counters_c(
+	int max_program_counters, int *num_program_counters, int skip) __attribute__((noinline));
 
 struct debugging_info {
 	char *filename;
@@ -39,11 +39,12 @@ struct debugging_info {
  * The returned array needs to be freed by the caller.
  * Char pointers in the returned structs need to be freed by the caller.
  */
-struct debugging_info *get_debugging_info_c(uintptr_t *program_counters, int max_length);
+struct debugging_info *get_debugging_info_c(
+	const uintptr_t *program_counters, int num_program_counters,
+	int max_debugging_infos, int *num_debugging_infos);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
 #endif // LIBBACKTRACE_WRAPPER_H
-


### PR DESCRIPTION
The `getDebuggingInfo` function relies on `programCounters` being a NULL terminated list. However, none of the usage actually adds NULL...

- In the path that passes `getProgramCounters` result into `getDebuggingInfo`, no explicit 0 value is added to `result`. In practice, there happens to be a 0 there very frequently, but it is not guaranteed (`env MallocScribble=1`), and even if it is not there the implementation often continues to work when processing the extra garbage data, silencing the problem.

- In the path from Nim `addDebuggingInfo` (`system/stacktraces.nim`), the `programCounters` list is constructed by Nim logic and also does not add a 0 value to the list. This means that even if we fix `getProgramCounters` to produce NULL terminated list, other usage is still broken, and outside the control of this library.

Therefore, remove the NULL terminator logic and pass length explicitly while retaining any early loop exits when encountering 0 for compat.

Also fix some memory leaks in error conditions.