### PR TITLE
Add script to bump `libunwind` dependency

### DIFF
--- a/UpdateLibunwind
+++ b/UpdateLibunwind
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")"
+
+git diff --exit-code -- . ':(exclude)UpdateLibunwind' > /dev/null || { echo "Commit changes before updating!" ; exit 1 ; }
+
+# https://github.com/llvm/llvm-project/releases
+COMMIT="${1:-f749550cfe9f0bf2364abb2139835348587062ed}"
+
+pushd vendor >/dev/null
+rm -rf libunwind llvm-project
+mkdir -p llvm-project
+pushd llvm-project >/dev/null
+git init
+git sparse-checkout set libunwind
+git remote add upstream "https://github.com/llvm/llvm-project"
+git fetch --depth 1 upstream "${COMMIT}"
+git checkout "${COMMIT}"
+popd >/dev/null
+mv llvm-project/libunwind .
+rm -rf llvm-project
+popd >/dev/null
+
+git -C vendor/libunwind apply <<'EOF'
+diff --git a/vendor/libunwind/.gitignore b/vendor/libunwind/.gitignore
+new file mode 100644
+index 0000000..fb7df50
+--- /dev/null
++++ b/vendor/libunwind/.gitignore
+@@ -0,0 +1,13 @@
++CMakeLists.txt.user
++CMakeCache.txt
++CMakeFiles
++CMakeScripts
++Testing
++Makefile
++cmake_install.cmake
++install_manifest.txt
++compile_commands.json
++CTestTestfile.cmake
++_deps
++*_autogen
++/test/lit.site.cfg
+diff --git a/vendor/libunwind/CMakeLists.txt b/vendor/libunwind/CMakeLists.txt
+index a2c03fd..7304d39 100644
+--- a/vendor/libunwind/CMakeLists.txt
++++ b/vendor/libunwind/CMakeLists.txt
+@@ -1,7 +1,3 @@
+-if (NOT IS_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../libcxx")
+-  message(FATAL_ERROR "libunwind requires being built in a monorepo layout with libcxx available")
+-endif()
+-
+ #===============================================================================
+ # Setup Project
+ #===============================================================================
+@@ -17,8 +13,6 @@ set(CMAKE_MODULE_PATH
+
+ set(LIBUNWIND_SOURCE_DIR  ${CMAKE_CURRENT_SOURCE_DIR})
+ set(LIBUNWIND_BINARY_DIR  ${CMAKE_CURRENT_BINARY_DIR})
+-set(LIBUNWIND_LIBCXX_PATH "${CMAKE_CURRENT_LIST_DIR}/../libcxx" CACHE PATH
+-        "Specify path to libc++ source.")
+
+ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR LIBUNWIND_STANDALONE_BUILD)
+   project(libunwind LANGUAGES C CXX ASM)
+@@ -28,18 +22,11 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR LIBUNWIND_STANDALONE_B
+   set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
+   set(PACKAGE_BUGREPORT "llvm-bugs@lists.llvm.org")
+
+-  # Add the CMake module path of libcxx so we can reuse HandleOutOfTreeLLVM.cmake
+-  set(LIBUNWIND_LIBCXX_CMAKE_PATH "${LIBUNWIND_LIBCXX_PATH}/cmake/Modules")
+-  list(APPEND CMAKE_MODULE_PATH "${LIBUNWIND_LIBCXX_CMAKE_PATH}")
+-
+   # In a standalone build, we don't have llvm to automatically generate the
+   # llvm-lit script for us.  So we need to provide an explicit directory that
+   # the configurator should write the script into.
+   set(LIBUNWIND_STANDALONE_BUILD 1)
+   set(LLVM_LIT_OUTPUT_DIR "${LIBUNWIND_BINARY_DIR}/bin")
+-
+-  # Find the LLVM sources and simulate LLVM CMake options.
+-  include(HandleOutOfTreeLLVM)
+ else()
+   set(LLVM_LIT "${CMAKE_SOURCE_DIR}/utils/lit/lit.py")
+ endif()
+EOF
+
+! git diff --exit-code > /dev/null || { echo "This repository is already up to date" ; exit 0 ; }
+
+git commit -a \
+  -m "Bump libunwind to \`${COMMIT}\`" \
+  -m "- https://github.com/llvm/llvm-project/commit/${COMMIT}"
+
+echo "The repo has been updated with a commit recording the update."
+echo "You can review the changes with 'git diff HEAD^' before pushing to a public repository."

--- a/vendor/libunwind/.gitignore
+++ b/vendor/libunwind/.gitignore
@@ -11,4 +11,3 @@ CTestTestfile.cmake
 _deps
 *_autogen
 /test/lit.site.cfg
-


### PR DESCRIPTION
To make `vendor/libunwind` reproducible, add a script containing the exact steps. `git sparse-checkout` config is not sharable through cfg.