### PR TITLE
remove macos-13 from the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
           - os: linux
             cpu: i386
           - os: macos
-            cpu: amd64
-          - os: macos
             cpu: arm64
           - os: windows
             cpu: amd64
@@ -25,10 +23,6 @@ jobs:
           - target:
               os: linux
             builder: ubuntu-latest
-          - target:
-              os: macos
-              cpu: amd64
-            builder: macos-13
           - target:
               os: macos
               cpu: arm64


### PR DESCRIPTION
It is no longer supported, starting from September 1st: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down